### PR TITLE
Add Slack notification workflow for PR events

### DIFF
--- a/.github/workflows/SlackNotification.yml
+++ b/.github/workflows/SlackNotification.yml
@@ -1,0 +1,22 @@
+name: Slack Notification
+
+on: 
+  pull_request_target:
+    types:
+      - ready_for_review
+      - opened
+jobs:
+  slackNotification:
+    if: ${{ contains(fromJSON('["OS-miguelfreitas", "OS-joaomurgeiro", "osjlopes", "mvios", "OS-alexandretome", "rmb-guerra", "OS-rodrigolopes", "OS-thiagosiqueira", "OS-luisvendrame", "OS-josecunha"]'), github.event.pull_request.user.login) && !github.event.pull_request.draft  }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: slackapi/slack-github-action@v2.0.0
+      with:
+        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook-type: webhook-trigger
+        payload: |
+          pr_url: "${{ github.event.pull_request.html_url }}"
+          pr_number : "${{ github.event.pull_request.number }}"
+          pr_title: "${{ github.event.pull_request.title }}"
+          pr_user: "${{ github.event.pull_request.user.login }}"
+          pr_reviewers : "${{ join( github.event.pull_request.requested_reviewers.*.login , ' , ' ) }}"


### PR DESCRIPTION
Introduces a GitHub Actions workflow to send Slack notifications when a pull request is opened or marked ready for review by specific users. The workflow uses a Slack webhook and includes PR details in the notification payload.




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
